### PR TITLE
Fix the representation of Theme model under Python 3

### DIFF
--- a/admin_interface/models.py
+++ b/admin_interface/models.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from django.core.files import File
 from django.db import models
 from django.db.models.signals import post_delete, post_save
+from django.utils.encoding import python_2_unicode_compatible, force_text
 
 from colorfield.fields import ColorField
 
 import os
 
 
+@python_2_unicode_compatible
 class Theme(models.Model):
 
     @staticmethod
@@ -134,9 +137,8 @@ class Theme(models.Model):
         verbose_name = 'Theme'
         verbose_name_plural = 'Themes'
 
-    def __unicode__(self):
-
-        return unicode(u'%s' % (self.name, ))
+    def __str__(self):
+        return force_text(self.name)
 
 
 post_delete.connect(Theme.post_delete_handler, sender = Theme)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -99,3 +99,7 @@ class AdminInterfaceTestCase(TestCase):
         rendered = self.__render_template('{% load admin_interface_tags %}{% get_admin_interface_theme as theme %}{{ theme.name }}')
         self.assertEqual(rendered, 'Django')
 
+    def test_repr(self):
+        theme = Theme.get_active_theme()
+        self.assertEqual( "{0}".format(theme), 'Django' )
+


### PR DESCRIPTION
On Python 3 the Theme model is printed as 'Theme object' because the representation string should be `__str__` instead of `__unicode__`.
The common pattern for that is to decorate models with `python_2_unicode_compatible` and only define the `__str__` method. On Python 2, the decorator renames this method to `__unicode__`.

- [x] Write test case to reproduce the problem
- [x] Write a fix