### PR TITLE
Fix a Django deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,18 @@ env:
   - TOX_ENV=py34-18
   - TOX_ENV=py34-19
   - TOX_ENV=py34-110
+  - TOX_ENV=py34-master
   - TOX_ENV=py35-18
   - TOX_ENV=py35-19
   - TOX_ENV=py35-110
+  - TOX_ENV=py35-master
   #- TOX_ENV=py36-18
   #- TOX_ENV=py36-19
   #- TOX_ENV=py36-110
+matrix:
+  allow_failures:
+    - env: TOX_ENV=py34-master
+    - env: TOX_ENV=py34-master
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 matrix:
   allow_failures:
     - env: TOX_ENV=py34-master
-    - env: TOX_ENV=py34-master
+    - env: TOX_ENV=py35-master
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,16 @@ env:
   - TOX_ENV=py35-19
   - TOX_ENV=py35-110
   - TOX_ENV=py35-master
-  #- TOX_ENV=py36-18
-  #- TOX_ENV=py36-19
-  #- TOX_ENV=py36-110
 matrix:
+  include:
+    - python: "3.6"
+      env: TOX_ENV=py36-111
+    - python: "3.6"
+      env: TOX_ENV=py36-master
   allow_failures:
     - env: TOX_ENV=py34-master
     - env: TOX_ENV=py35-master
+    - env: TOX_ENV=py36-master
 install:
   - pip install tox
 script:

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -7,8 +7,13 @@ from admin_interface.models import Theme
 
 register = template.Library()
 
+try:
+    assignment_tag = register.assignment_tag
+except AttributeError:
+    assignment_tag = register.simple_tag
 
-@register.simple_tag(takes_context = True)
+
+@assignment_tag(takes_context = True)
 def get_admin_interface_theme(context):
 
     theme = None

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -8,7 +8,7 @@ from admin_interface.models import Theme
 register = template.Library()
 
 
-@register.assignment_tag(takes_context = True)
+@register.simple_tag(takes_context = True)
 def get_admin_interface_theme(context):
 
     theme = None

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     py27-{17,18,19,110,111},
-    py34-{17,18,19,110,111},
-    py35-{18,19,110,111},
-    py36-{18,19,110,111},
+    py34-{17,18,19,110,111,master},
+    py35-{18,19,110,111,master},
+    py36-{18,19,110,111,master},
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
@@ -12,6 +12,7 @@ deps =
     19: Django >= 1.9, < 1.10
     110: Django >= 1.10, < 1.11
     111: Django >= 1.11, < 1.12
+    master: https://github.com/django/django/archive/master.tar.gz
     coverage
     codecov
 commands =


### PR DESCRIPTION
Replace deprecated assignment_tag:

`python/lib/python3.5/site-packages/admin_interface/templatetags/admin_interface_tags.py:11: RemovedInDjango20Warning: assignment_tag() is deprecated. Use simple_tag() instead`

Also updated the build matrix to attempt building on Django master and Python 3.6.