### PR TITLE
Specify a max_length on all ColorFields.

### DIFF
--- a/admin_interface/models.py
+++ b/admin_interface/models.py
@@ -51,39 +51,39 @@ class Theme(models.Model):
     active = models.BooleanField( default = True )
 
     title = models.CharField( max_length = 50, default = 'Django administration', blank = True )
-    title_color = ColorField( blank = True, default = '#F5DD5D', help_text = '#F5DD5D', verbose_name = 'title color' )
+    title_color = ColorField( blank = True, default = '#F5DD5D', help_text = '#F5DD5D', max_length = 10, verbose_name = 'title color' )
     title_visible = models.BooleanField( default = True, verbose_name = 'visible' )
 
     logo = models.FileField( upload_to = 'admin-interface/logo/', blank = True, help_text = '(leave blank to use the default Django logo)' )
-    logo_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', verbose_name = 'logo color' )
+    logo_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', max_length = 10, verbose_name = 'logo color' )
     logo_visible = models.BooleanField( default = True, verbose_name = 'visible' )
 
-    css_header_background_color = ColorField( blank = True, default = '#0C4B33', help_text = '#0C4B33', verbose_name = 'background color' )
-    css_header_text_color = ColorField( blank = True, default = '#44B78B', help_text = '#44B78B', verbose_name = 'text color' )
-    css_header_link_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', verbose_name = 'link color' )
-    css_header_link_hover_color = ColorField( blank = True, default = '#C9F0DD', help_text = '#C9F0DD', verbose_name = 'link hover color' )
+    css_header_background_color = ColorField( blank = True, default = '#0C4B33', help_text = '#0C4B33', max_length = 10, verbose_name = 'background color' )
+    css_header_text_color = ColorField( blank = True, default = '#44B78B', help_text = '#44B78B', max_length = 10, verbose_name = 'text color' )
+    css_header_link_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', max_length = 10, verbose_name = 'link color' )
+    css_header_link_hover_color = ColorField( blank = True, default = '#C9F0DD', help_text = '#C9F0DD', max_length = 10, verbose_name = 'link hover color' )
 
-    css_module_background_color = ColorField( blank = True, default = '#44B78B', help_text = '#44B78B', verbose_name = 'background color' )
-    css_module_text_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', verbose_name = 'text color' )
-    css_module_link_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', verbose_name = 'link color' )
-    css_module_link_hover_color = ColorField( blank = True, default = '#C9F0DD', help_text = '#C9F0DD', verbose_name = 'link hover color' )
+    css_module_background_color = ColorField( blank = True, default = '#44B78B', help_text = '#44B78B', max_length = 10, verbose_name = 'background color' )
+    css_module_text_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', max_length = 10, verbose_name = 'text color' )
+    css_module_link_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', max_length = 10, verbose_name = 'link color' )
+    css_module_link_hover_color = ColorField( blank = True, default = '#C9F0DD', help_text = '#C9F0DD', max_length = 10, verbose_name = 'link hover color' )
     css_module_rounded_corners = models.BooleanField( default = True, verbose_name = 'rounded corners' )
 
-    css_generic_link_color = ColorField( blank = True, default = '#0C3C26', help_text = '#0C3C26', verbose_name = 'link color' )
-    css_generic_link_hover_color = ColorField( blank = True, default = '#156641', help_text = '#156641', verbose_name = 'link hover color' )
+    css_generic_link_color = ColorField( blank = True, default = '#0C3C26', help_text = '#0C3C26', max_length = 10, verbose_name = 'link color' )
+    css_generic_link_hover_color = ColorField( blank = True, default = '#156641', help_text = '#156641', max_length = 10, verbose_name = 'link hover color' )
 
-    css_save_button_background_color = ColorField( blank = True, default = '#0C4B33', help_text = '#0C4B33', verbose_name = 'background color' )
-    css_save_button_background_hover_color = ColorField( blank = True, default = '#0C3C26', help_text = '#0C3C26', verbose_name = 'background hover color' )
-    css_save_button_text_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', verbose_name = 'text color' )
+    css_save_button_background_color = ColorField( blank = True, default = '#0C4B33', help_text = '#0C4B33', max_length = 10, verbose_name = 'background color' )
+    css_save_button_background_hover_color = ColorField( blank = True, default = '#0C3C26', help_text = '#0C3C26', max_length = 10, verbose_name = 'background hover color' )
+    css_save_button_text_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', max_length = 10, verbose_name = 'text color' )
 
-    css_delete_button_background_color = ColorField( blank = True, default = '#BA2121', help_text = '#BA2121', verbose_name = 'background color' )
-    css_delete_button_background_hover_color = ColorField( blank = True, default = '#A41515', help_text = '#A41515', verbose_name = 'background hover color' )
-    css_delete_button_text_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', verbose_name = 'text color' )
+    css_delete_button_background_color = ColorField( blank = True, default = '#BA2121', help_text = '#BA2121', max_length = 10, verbose_name = 'background color' )
+    css_delete_button_background_hover_color = ColorField( blank = True, default = '#A41515', help_text = '#A41515', max_length = 10, verbose_name = 'background hover color' )
+    css_delete_button_text_color = ColorField( blank = True, default = '#FFFFFF', help_text = '#FFFFFF', max_length = 10, verbose_name = 'text color' )
 
     css = models.TextField( blank = True )
 
     related_modal_active = models.BooleanField( default = True, verbose_name = 'active' )
-    related_modal_background_color = ColorField( blank = True, default = '#000000', help_text = '#000000', verbose_name = 'background color' )
+    related_modal_background_color = ColorField( blank = True, default = '#000000', help_text = '#000000', max_length = 10, verbose_name = 'background color' )
     related_modal_background_opacity_choices = (
         (0.1, '10%', ),
         (0.2, '20%', ),


### PR DESCRIPTION
Django-colorfield bumped up its default max_length from 10 to 18 characters in
bfe421b8. Though we've pinned the version of colorfields we're depending on,
we can make the future version upgrade easier now by locking our fields to
having a max length of 10 chars.