### PR TITLE
Add USWDS color scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@ This package ships with optional themes as fixtures, they can be installed using
 ##### Django theme (default):
 Run ``python manage.py loaddata admin_interface_theme_django.json``
 
-##### Bootstrap theme: 
+##### [Bootstrap](http://getbootstrap.com/) theme: 
 Run ``python manage.py loaddata admin_interface_theme_bootstrap.json``
 
-##### Foundation theme: 
+##### [Foundation](http://foundation.zurb.com/) theme: 
 Run ``python manage.py loaddata admin_interface_theme_foundation.json``
+
+##### [U.S. Web Design Standards](https://standards.usa.gov/) theme:
+Run ``python manage.py loaddata admin_interface_theme_uswds.json``
 
 ### Add more themes
 You can add a theme you've created through the admin to this repository by [sending us a PR](http://makeapullrequest.com/). Here are the steps to follow to add :

--- a/admin_interface/fixtures/admin_interface_theme_uswds.json
+++ b/admin_interface/fixtures/admin_interface_theme_uswds.json
@@ -1,0 +1,39 @@
+[
+    {
+        "model": "admin_interface.theme",
+        "fields": {
+            "name": "USWDS",
+            "active": true,
+            "title": "Site administration",
+            "title_color": "#FFFFFF",
+            "title_visible": true,
+            "logo": "",
+            "logo_color": "#FFFFFF",
+            "logo_visible": false,
+            "css_header_background_color": "#112E51",
+            "css_header_text_color": "#FFFFFF",
+            "css_header_link_color": "#FFFFFF",
+            "css_header_link_hover_color": "#E1F3F8",
+            "css_module_background_color": "#205493",
+            "css_module_text_color": "#FFFFFF",
+            "css_module_link_color": "#FFFFFF",
+            "css_module_link_hover_color": "#E1F3F8",
+            "css_module_rounded_corners": true,
+            "css_generic_link_color": "#205493",
+            "css_generic_link_hover_color": "#0071BC",
+            "css_save_button_background_color": "#205493",
+            "css_save_button_background_hover_color": "#112E51",
+            "css_save_button_text_color": "#FFFFFF",
+            "css_delete_button_background_color": "#CD2026",
+            "css_delete_button_background_hover_color": "#981B1E",
+            "css_delete_button_text_color": "#FFFFFF",
+            "css": "",
+            "related_modal_active": true,
+            "related_modal_background_color": "#000000",
+            "related_modal_background_opacity": 0.8,
+            "related_modal_rounded_corners": true,
+            "list_filter_dropdown": false,
+            "recent_actions_visible": true
+        }
+    }
+]


### PR DESCRIPTION
As a first draft of a U.S. Web Design Standards theme, this selects
reasonable colors from its 508-compliant color pallet.

@fabiocaccamo I *think* I did this right, but let me know if I missed a step.

Looks like
![uswds-django](https://user-images.githubusercontent.com/326918/27056791-92c828ac-4f97-11e7-9d48-1ed46037f95f.png)
