### PR TITLE
Avoid deprecation warning about assignment_tag

### DIFF
--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 
-from django import template
+from django import template, VERSION
 
 from admin_interface.models import Theme
 from admin_interface.version import __version__
 
 register = template.Library()
 
-try:
-    assignment_tag = register.assignment_tag
-except AttributeError:
-    assignment_tag = register.simple_tag
+if VERSION < (1, 9):
+    simple_tag = register.assignment_tag
+else:
+    simple_tag = register.simple_tag
 
 
-@assignment_tag(takes_context=True)
+@simple_tag(takes_context=True)
 def get_admin_interface_theme(context):
-
     theme = None
     request = context.get('request', None)
 
@@ -31,6 +30,6 @@ def get_admin_interface_theme(context):
     return theme
 
 
-@assignment_tag(takes_context=False)
+@simple_tag(takes_context=False)
 def get_admin_interface_version():
     return __version__


### PR DESCRIPTION
Even though the try/except is Django 2.0 compatible, it still accesses the deprecated template tag, and therefore it emits a deprecation warning in the console, whereas it's actually fixed.

I tried to swap the try and the catch, but it doesn't work: `simple_tag` existed before 1.9 but in a non-compatible form.

I've also changed the decorator name we use to match the new Django version, it should make the codebase more future proof.