### PR TITLE
support show_change_link with related modal

### DIFF
--- a/admin_interface/static/admin_interface/related-modal/related-modal.js
+++ b/admin_interface/static/admin_interface/related-modal/related-modal.js
@@ -145,6 +145,9 @@ if (typeof(django) !== 'undefined' && typeof(django.jQuery) !== 'undefined')
             // django-dynamic-raw-id support - #61
             // https://github.com/lincolnloop/django-dynamic-raw-id
             presentRelatedObjectModalOnClickOn('a.dynamic_raw_id-related-lookup', true);
+
+            // show_change_link=True support
+            presentRelatedObjectModalOnClickOn('a.inlinechangelink');
         });
 
     })(django.jQuery);


### PR DESCRIPTION
add support for [`show_change_link=True`](https://docs.djangoproject.com/en/3.1/ref/contrib/admin/#django.contrib.admin.InlineModelAdmin.show_change_link) usage with the related modal
![image](https://user-images.githubusercontent.com/8385247/111194875-eb6b7a00-85bb-11eb-8727-ec346098737e.png)
