### PR TITLE
migration fixed for multiple dbs

### DIFF
--- a/admin_interface/migrations/0020_module_selected_colors.py
+++ b/admin_interface/migrations/0020_module_selected_colors.py
@@ -10,7 +10,8 @@ import colorfield.fields
 
 def default_link_selected(apps, schema_editor):
     Theme = apps.get_model("admin_interface", "Theme")
-    Theme.objects.update(
+    db_alias = schema_editor.connection.alias
+    Theme.objects.using(db_alias).update(
         css_module_link_selected_color=F('css_module_link_color'))
 
 


### PR DESCRIPTION
This will fix the migrations from indefinitely hanging if Django has multiple databases, with one being a "read-only" db.