### PR TITLE
docs: Fix a few typos

### DIFF
--- a/admin_interface/static/admin_interface/magnific-popup/jquery.magnific-popup.js
+++ b/admin_interface/static/admin_interface/magnific-popup/jquery.magnific-popup.js
@@ -1507,7 +1507,7 @@
                 }
             },
 
-            // Get element postion relative to viewport
+            // Get element position relative to viewport
             _getOffset: function(isLarge) {
                 var el;
                 if(isLarge) {

--- a/admin_interface/static/ckeditor/ckeditor/skins/light/skin.js
+++ b/admin_interface/static/ckeditor/ckeditor/skins/light/skin.js
@@ -49,7 +49,7 @@ CKEDITOR.skin.name = 'husky';
 // the complete list:
 // http://docs.ckeditor.com/#!/api/CKEDITOR.env
 //
-// Internet explorer is an expection and the browser version is also accepted
+// Internet explorer is an exception and the browser version is also accepted
 // (ie7, ie8, ie9, ie10), as well as a special name for IE in Quirks mode (iequirks).
 //
 // The available browser specific files must be set separately for editor.css


### PR DESCRIPTION
There are small typos in:
- admin_interface/static/admin_interface/magnific-popup/jquery.magnific-popup.js
- admin_interface/static/ckeditor/ckeditor/skins/light/skin.js

Fixes:
- Should read `position` rather than `postion`.
- Should read `exception` rather than `expection`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md