### PR TITLE
Fix typo in French language name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You must configure multilanguage `settings` and `urls` correctly:
 LANGUAGES = (
     ("en", _("English")),
     ("it", _("Italiano")),
-    ("fr", _("Française")),
+    ("fr", _("Français")),
     # more than one language is expected here
 )
 LANGUAGE_CODE = "en"


### PR DESCRIPTION
https://fr.wikipedia.org/wiki/Français

"e" is for feminine, and it's correct that the "language" in French is feminine, but the name of the French language specifically is masculine (le français), so "e" is not necessary.