### PR TITLE
Add border to rest of the tab space

### DIFF
--- a/admin_interface/migrations/0028_theme_show_fieldsets_as_tabs_and_more.py
+++ b/admin_interface/migrations/0028_theme_show_fieldsets_as_tabs_and_more.py
@@ -18,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="theme",
             name="show_inlines_as_tabs",
-            field=models.BooleanField(default=True, verbose_name="inlines as tabs"),
+            field=models.BooleanField(default=False, verbose_name="inlines as tabs"),
         ),
     ]

--- a/admin_interface/models.py
+++ b/admin_interface/models.py
@@ -356,7 +356,7 @@ class Theme(models.Model):
     )
 
     show_inlines_as_tabs = models.BooleanField(
-        default=True, verbose_name=_("inlines as tabs")
+        default=False, verbose_name=_("inlines as tabs")
     )
 
     recent_actions_visible = models.BooleanField(

--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -3,12 +3,21 @@
     flex-direction: row;
     flex-wrap: nowrap;
     overflow-x: auto;
-    padding-bottom: 10px;
+    padding-bottom: 8px;
+    scrollbar-width: 4px;
 }
+
+.admin-interface .tabbed-changeform-tab::-webkit-scrollbar {
+    height: 4px;
+    background-color: var(--border-color);
+}
+.admin-interface .tabbed-changeform-tab::-webkit-scrollbar-thumb {
+    background:  #aaa; 
+  }
 
 .admin-interface .tabbed-changeform-tab button {
     border: none;
-    border-bottom: 1px solid var(--border-color) ;
+    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
     flex-grow: 0;
     cursor: pointer;
@@ -20,7 +29,7 @@
 .admin-interface .tabbed-changeform-tab button.active {
     outline: none;
     font-weight: bold;
-    border: 1px solid var(--border-color) ;
+    border: 1px solid var(--border-color);
     border-bottom: none;
     border-radius: var(--admin-interface-module-border-radius);
     border-bottom-left-radius: 0px;
@@ -38,5 +47,5 @@
 
 .admin-interface .tabbed-changeform-tabs-remaining-space {
     flex: 1;
-    border-bottom: 1px solid var(--border-color) ;
+    border-bottom: 1px solid var(--border-color);
 }

--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -15,13 +15,17 @@
     background:  #aaa; 
   }
 
+
 .admin-interface .tabbed-changeform-tab button {
+    -webkit-appearance: none;
     border: none;
+    border-radius: 0;
     border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
     flex-grow: 0;
     cursor: pointer;
     padding: 8px 12px;
+    margin: 0;
     background-color: var(--admin-interface-module-header-text-color);
     color: var(--admin-interface-module-background-color);
 }

--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -33,3 +33,8 @@
 .admin-interface .tabbed-changeform-tabcontent.active {
     display: block;
 }
+
+.admin-interface #rest-of-the-tabber {
+    flex: 1;
+    border-bottom: 1px solid var(--border-color) ;
+}

--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -12,7 +12,7 @@
     background-color: var(--border-color);
 }
 .admin-interface .tabbed-changeform-tab::-webkit-scrollbar-thumb {
-    background:  #aaa; 
+    background:  #aaa;
   }
 
 

--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -3,6 +3,7 @@
     flex-direction: row;
     flex-wrap: nowrap;
     overflow-x: auto;
+    padding-bottom: 10px;
 }
 
 .admin-interface .tabbed-changeform-tab button {

--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -18,6 +18,7 @@
 }
 
 .admin-interface .tabbed-changeform-tab button.active {
+    outline: none;
     font-weight: bold;
     border: 1px solid var(--border-color) ;
     border-bottom: none;
@@ -35,7 +36,7 @@
     display: block;
 }
 
-.admin-interface #rest-of-the-tabber {
+.admin-interface .tabbed-changeform-tabs-remaining-space {
     flex: 1;
     border-bottom: 1px solid var(--border-color) ;
 }

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -6,9 +6,9 @@
 
 {% get_admin_interface_setting "show_fieldsets_as_tabs" as show_fieldsets_as_tabs %}
 {% get_admin_interface_setting "show_inlines_as_tabs" as show_inlines_as_tabs %}
-{% has_multiple_tabs adminform inline_admin_formsets as has_multiple_tabs %}
+{% admin_interface_use_changeform_tabs adminform inline_admin_formsets as admin_interface_use_changeform_tabs %}
 
-{% if not has_multiple_tabs %}
+{% if not admin_interface_use_changeform_tabs %}
 
 {{block.super}}
 

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -17,7 +17,7 @@
 
       {% if show_fieldsets_as_tabs %}
         {% for fieldset in adminform %}
-        <button type="button" class="tabbed-changeform-tablinks {{ forloop.counter0|default:"active" }}" onclick="openTab(event, '{{fieldset.name}}')">
+        <button type="button" class="tabbed-changeform-tablinks {{ forloop.counter0|default:"active" }}" onclick="openTab(event, 'tab-{{fieldset.name|slugify}}')">
             {{ fieldset.name|default_if_none:opts.verbose_name|capfirst}}
         </button>
         {% endfor %}
@@ -29,7 +29,7 @@
 
      {% if show_inlines_as_tabs %}
         {% for inline_admin_formset in inline_admin_formsets %}
-        <button type="button" class="tabbed-changeform-tablinks" onclick="openTab(event, '{{inline_admin_formset.opts.verbose_name_plural|capfirst}}')">
+        <button type="button" class="tabbed-changeform-tablinks" onclick="openTab(event, 'tab-{{inline_admin_formset.opts.verbose_name_plural|slugify}}')">
             {{inline_admin_formset.opts.verbose_name_plural|capfirst}}
         </button>
         {% endfor %}
@@ -40,7 +40,7 @@
 
     {% if show_fieldsets_as_tabs %}
       {% for fieldset in adminform %}
-      <div id="{{fieldset.name}}" class="tabbed-changeform-tabcontent {{ forloop.counter0|default:"active" }}">
+      <div id="tab-{{fieldset.name|slugify}}" class="tabbed-changeform-tabcontent {{ forloop.counter0|default:"active" }}">
           {% include "admin/includes/headerless_fieldset.html" %}
       </div>
       {% endfor %}
@@ -53,7 +53,7 @@
     {% endif %}
 
     {% for inline_admin_formset in inline_admin_formsets  %}
-    <div id="{{inline_admin_formset.opts.verbose_name_plural|capfirst}}" class="tabbed-changeform-tabcontent">
+    <div id="tab-{{inline_admin_formset.opts.verbose_name_plural|slugify}}" class="tabbed-changeform-tabcontent">
       {% get_admin_interface_inline_template inline_admin_formset.opts.template as inline_template %}
       {% include inline_template %}
     </div>

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -6,8 +6,9 @@
 
 {% get_admin_interface_setting "show_fieldsets_as_tabs" as show_fieldsets_as_tabs %}
 {% get_admin_interface_setting "show_inlines_as_tabs" as show_inlines_as_tabs %}
+{% has_multiple_tabs adminform inline_admin_formsets as has_multiple_tabs %}
 
-{% if not show_fieldsets_as_tabs and not show_inlines_as_tabs %}
+{% if not has_multiple_tabs %}
 
 {{block.super}}
 

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -35,7 +35,7 @@
         </button>
         {% endfor %}
       {% endif %}
-      <div id="rest-of-the-tabber"></div>
+      <div class="tabbed-changeform-tabs-remaining-space"></div>
 
     </div>
 

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -34,6 +34,8 @@
         </button>
         {% endfor %}
       {% endif %}
+      <div id="rest-of-the-tabber"></div>
+
     </div>
 
     {% if show_fieldsets_as_tabs %}

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -128,3 +128,11 @@ def admin_interface_filter_removal_link(changelist, list_filter):
             "title": title,
         }
     )
+
+@simple_tag()
+def has_multiple_tabs(adminform, inline_forms):
+    theme = get_admin_interface_theme()
+    has_fieldset_tabs = getattr(theme, "show_fieldsets_as_tabs") and len(adminform.fieldsets) > 1 
+    has_inline_tabs = getattr(theme, "show_inlines_as_tabs") and len(inline_forms) > 0 
+    has_tabs = has_fieldset_tabs or has_inline_tabs
+    return has_tabs

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -133,9 +133,7 @@ def admin_interface_filter_removal_link(changelist, list_filter):
 @simple_tag()
 def has_multiple_tabs(adminform, inline_forms):
     theme = get_admin_interface_theme()
-    has_fieldset_tabs = (
-        getattr(theme, "show_fieldsets_as_tabs") and len(adminform.fieldsets) > 1
-    )
-    has_inline_tabs = getattr(theme, "show_inlines_as_tabs") and len(inline_forms) > 0
+    has_fieldset_tabs = theme.show_fieldsets_as_tabs and len(adminform.fieldsets) > 1 
+    has_inline_tabs = theme.show_inlines_as_tabs and len(inline_forms) > 0 
     has_tabs = has_fieldset_tabs or has_inline_tabs
     return has_tabs

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -129,10 +129,13 @@ def admin_interface_filter_removal_link(changelist, list_filter):
         }
     )
 
+
 @simple_tag()
 def has_multiple_tabs(adminform, inline_forms):
     theme = get_admin_interface_theme()
-    has_fieldset_tabs = getattr(theme, "show_fieldsets_as_tabs") and len(adminform.fieldsets) > 1 
-    has_inline_tabs = getattr(theme, "show_inlines_as_tabs") and len(inline_forms) > 0 
+    has_fieldset_tabs = (
+        getattr(theme, "show_fieldsets_as_tabs") and len(adminform.fieldsets) > 1
+    )
+    has_inline_tabs = getattr(theme, "show_inlines_as_tabs") and len(inline_forms) > 0
     has_tabs = has_fieldset_tabs or has_inline_tabs
     return has_tabs

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -131,7 +131,7 @@ def admin_interface_filter_removal_link(changelist, list_filter):
 
 
 @simple_tag()
-def has_multiple_tabs(adminform, inline_forms):
+def admin_interface_use_changeform_tabs(adminform, inline_forms):
     theme = get_admin_interface_theme()
     has_fieldset_tabs = theme.show_fieldsets_as_tabs and len(adminform.fieldsets) > 1
     has_inline_tabs = theme.show_inlines_as_tabs and len(inline_forms) > 0

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -133,7 +133,7 @@ def admin_interface_filter_removal_link(changelist, list_filter):
 @simple_tag()
 def has_multiple_tabs(adminform, inline_forms):
     theme = get_admin_interface_theme()
-    has_fieldset_tabs = theme.show_fieldsets_as_tabs and len(adminform.fieldsets) > 1 
-    has_inline_tabs = theme.show_inlines_as_tabs and len(inline_forms) > 0 
+    has_fieldset_tabs = theme.show_fieldsets_as_tabs and len(adminform.fieldsets) > 1
+    has_inline_tabs = theme.show_inlines_as_tabs and len(inline_forms) > 0
     has_tabs = has_fieldset_tabs or has_inline_tabs
     return has_tabs


### PR DESCRIPTION
Handles comments at https://github.com/fabiocaccamo/django-admin-interface/pull/211#issuecomment-1329441796

- [X] `Inlines as tabs` : False by default
- [X] Add consistent styling for all changeform tabs*
- [x] Hide tabs when no extra fieldset / inline exists
- [X] Spacing between tab and scrollbar
- [ ] remember selection when using "save and continue editing"
- [ ] Unexpected border/outline onload (to be investigated for reproduction
