### PR TITLE
Text color on focus

### DIFF
--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -42,6 +42,10 @@
     color: var(--admin-interface-generic-link-hover-color);
 }
 
+.admin-interface .tabbed-changeform-tabs .tabbed-changeform-tablink:focus {
+    color: var(--admin-interface-generic-link-hover-color);
+}
+
 .admin-interface .tabbed-changeform-tabs .tabbed-changeform-tablink.active {
     border: 1px solid var(--border-color);
     border-bottom: 1px solid transparent;


### PR DESCRIPTION
Just a minor css update to enable focusing when using tab key.
[Screencast from 2022-12-09 10-16-37.webm](https://user-images.githubusercontent.com/11616688/206675273-60eee86d-0dfc-46fe-9f1d-ba8f92693865.webm)
