### PR TITLE
[css] Fix active tablink text color

### DIFF
--- a/admin_interface/static/admin_interface/css/tabbed-changeform.css
+++ b/admin_interface/static/admin_interface/css/tabbed-changeform.css
@@ -49,7 +49,7 @@
 .admin-interface .tabbed-changeform-tabs .tabbed-changeform-tablink.active {
     border: 1px solid var(--border-color);
     border-bottom: 1px solid transparent;
-    color: var(--admin-interface-module-background-color);
+    color: var(--admin-interface-module-text-color);
 }
 
 .admin-interface .tabbed-changeform-tabs-remaining-space {


### PR DESCRIPTION
Active tablinks uses module background color for texts now. That may make them barely visible:

![tablink-old](https://user-images.githubusercontent.com/1956472/207836196-5797b277-cb3d-4006-b6e6-15abd1510647.png)

Fixed by changing them to module text color which should be more appropriate:

![tablink-new](https://user-images.githubusercontent.com/1956472/207836291-a1cfb5e7-91c7-48ed-be4c-20ccb0fc6cf3.png)
