### PR TITLE
Fix/missing context vars

### DIFF
--- a/admin_interface/templates/admin/base_site.html
+++ b/admin_interface/templates/admin/base_site.html
@@ -146,6 +146,9 @@ admin-interface
 {% if theme.list_filter_highlight %} list-filter-highlight {% endif %}
 {% if theme.list_filter_sticky %} list-filter-sticky {% endif %}
 
+{% resolve_variable "adminform" as adminform %}
+{% resolve_variable "inline_admin_formsets" as inline_admin_formsets %}
+
 {% if adminform and inline_admin_formsets %}
 {% admin_interface_use_changeform_tabs adminform inline_admin_formsets as admin_interface_use_changeform_tabs %}
 {% if admin_interface_use_changeform_tabs %}

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -188,6 +188,11 @@ def admin_interface_use_changeform_tabs(adminform, inline_forms):
     return has_tabs
 
 
+@register.simple_tag(takes_context=True)
+def resolve_variable(context, var_name, default=""):
+    return context.get(var_name, default)
+
+
 @register.filter
 def admin_interface_slugify(name):
     return slugify(str(name or ""))

--- a/tests/test_resolve_variable.py
+++ b/tests/test_resolve_variable.py
@@ -1,0 +1,31 @@
+from django.template import Context, Template
+from django.test import SimpleTestCase
+
+
+class ResolveVariableTagTests(SimpleTestCase):
+    def render_template(self, tpl, context=None):
+        if context is None:
+            context = {}
+        return (
+            Template("{% load admin_interface_tags %}" + tpl)
+            .render(Context(context))
+            .strip()
+        )
+
+    def test_returns_existing_variable(self):
+        out = self.render_template(
+            '{% resolve_variable "myvar" as result %}{{ result }}', {"myvar": "hello"}
+        )
+        self.assertEqual(out, "hello")
+
+    def test_returns_default_when_missing(self):
+        out = self.render_template(
+            '{% resolve_variable "missingvar" as result %}{{ result }}'
+        )
+        self.assertEqual(out, "")
+
+    def test_returns_custom_default(self):
+        out = self.render_template(
+            '{% resolve_variable "missingvar" "fallback" as result %}{{ result }}'
+        )
+        self.assertEqual(out, "fallback")


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
This PR adds a `resolve_variable` template tag to safely handle missing context variables in `base_site.html`, preventing `VariableDoesNotExist` log noise.

- `resolve_variable` returns an empty string or a custom default instead of raising exceptions.  
- Updated `base_site.html` to use it for `adminform` and `inline_admin_formsets`.  
- Added tests to ensure correct behavior with existing, missing, and default values.

Missing context variables are harmless, but with template logging they generate `VariableDoesNotExist` logs, creating noise. `resolve_variable` can prevent this when used as a guard.

Alternative :- 
In our production, we suppressed via Django’s `LOGGING` config in `settings.py`:

```python
LOGGING = {
    "loggers": {
        "django.template": {
            "handlers": ["null"],
            "level": "WARNING",
            "propagate": False
        }
    }
}
```

**Related issue**
#446 

**Checklist before requesting a review**
- [X] I have performed a self-review of my code.
- [X] I have added tests for the proposed changes.
- [X] I have run the tests and there are not errors.
