### PR TITLE
fix modal popup navigation links

### DIFF
--- a/admin_interface/static/admin_interface/related-modal/related-modal.js
+++ b/admin_interface/static/admin_interface/related-modal/related-modal.js
@@ -143,8 +143,8 @@ if (typeof(django) !== 'undefined' && typeof(django.jQuery) !== 'undefined') {
             // show_change_link=True support
             presentRelatedObjectModalOnClickOn('a.inlinechangelink');
 
-            // any link with _popup=1 parameter support excluding those inside .paginator (see #420)
-            presentRelatedObjectModalOnClickOn('a[href*="_popup=1"]:not(.paginator a)');
+            // any link with _popup=1 parameter support excluding pagination, date hierarchy, filters and search links (see #420)
+            presentRelatedObjectModalOnClickOn('a[href*="_popup=1"]:not(.paginator a, .toplinks a, #changelist-filter-extra-actions a, #changelist-search a)');
 
             // django-streamfield support
             // https://github.com/raagin/django-streamfield/


### PR DESCRIPTION
**Describe your changes**
Extends the query selector to also exclude links in modal popups that change the current selection of objects. This relates mostly to modals for `raw_id_fields`.

**Related issue**
Previously reported in #420 

Links for pagination were fixed, however the same modal may also contain links that should not open a new modal:
- `date_hierarchy`
  <img width="273" height="123" alt="image" src="https://github.com/user-attachments/assets/a2f68a08-e505-4c92-8a88-395b63dcb760" />

- all objects link in search results ("%(count)d total")
  <img width="243" height="67" alt="image" src="https://github.com/user-attachments/assets/dc5079cb-a542-4635-b23a-a4c20c9e692b" />

- "Clear all filters" and "Show counts" links on the filters on the right
  <img width="247" height="171" alt="image" src="https://github.com/user-attachments/assets/dc34d7bf-bf7b-49b4-a2b7-4fe5d4830103" />

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.
