### PR TITLE
Add styling support for django-object-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ django-admin-interface is a modern **responsive flat admin interface customizabl
   - `django-dynamic-raw-id`
   - `django-json-widget`
   - `django-modeltranslation`
+  - `django-object-actions`
   - `django-rangefilter`
   - `django-streamfield`
   - `django-tabbed-admin`

--- a/admin_interface/templates/admin/change_form.html
+++ b/admin_interface/templates/admin/change_form.html
@@ -1,6 +1,19 @@
 {% extends "admin/change_form.html" %}
 {% load admin_interface_tags static %}
 
+{% block object-tools-items %}
+  {% admin_interface_use_object_actions adminform.model_admin as show_object_actions %}
+  {% if show_object_actions %}
+    {% for tool in objectactions %}
+        <li class="objectaction-item" data-tool-name="{{ tool.name }}">
+        {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+        {% include 'django_object_actions/action_trigger.html' %}
+        </li>
+    {% endfor %}
+  {% endif %}
+  {{ block.super }}
+{% endblock object-tools-items %}
+
 {% block field_sets %}
 
     {% get_admin_interface_setting "show_fieldsets_as_tabs" as show_fieldsets_as_tabs %}

--- a/admin_interface/templates/admin/change_list.html
+++ b/admin_interface/templates/admin/change_list.html
@@ -1,5 +1,19 @@
 {% extends "admin/change_list.html" %}
 {% load admin_interface_tags admin_list i18n %}
+
+{% block object-tools-items %}
+  {% admin_interface_use_object_actions cl.model_admin as show_object_actions %}
+  {% if show_object_actions %}
+    {% for tool in objectactions %}
+        <li class="objectaction-item" data-tool-name="{{ tool.name }}">
+        {% url tools_view_name tool=tool.name as action_url %}
+        {% include 'django_object_actions/action_trigger.html' %}
+        </li>
+    {% endfor %}
+  {% endif %}
+  {{ block.super }}
+{% endblock object-tools-items %}
+
 {# copied from django 5.1.2 #}
 
 {% block filters %}

--- a/admin_interface/templatetags/admin_interface_tags.py
+++ b/admin_interface/templatetags/admin_interface_tags.py
@@ -15,6 +15,13 @@ from admin_interface.cache import get_cached_active_theme, set_cached_active_the
 from admin_interface.metadata import __version__
 from admin_interface.models import Theme
 
+try:
+    from django_object_actions import BaseDjangoObjectActions
+
+    DJANGO_OBJECT_ACTIONS_INSTALLED = True
+except ImportError:
+    DJANGO_OBJECT_ACTIONS_INSTALLED = False
+
 register = template.Library()
 
 
@@ -191,3 +198,10 @@ def admin_interface_use_changeform_tabs(adminform, inline_forms):
 @register.filter
 def admin_interface_slugify(name):
     return slugify(str(name or ""))
+
+
+@register.simple_tag
+def admin_interface_use_object_actions(model_admin):
+    return DJANGO_OBJECT_ACTIONS_INSTALLED and isinstance(
+        model_admin, BaseDjangoObjectActions
+    )


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**

A common pattern for adding object tools to a particular ModelAdmin's changeform and changelist templates without overriding templates (and wading into the sticky world of template inheritance) is to use the [`django-object-actions`](https://github.com/crccheck/django-object-actions) app - actively maintained for years, 795 stars.

When the library is installed and a particular ModelAdmin uses its mixin, this PR injects the functionality of that app into the base change_form and change_list templates. When it's absent or a ModelAdmin isn't inheriting from their base class, it fallsback gracefully.

**Related issue**
None.

**Checklist before requesting a review**
- [X] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [ ] I have run the tests and there are not errors.
