### PR TITLE
Fix admin date/time picker popup width

### DIFF
--- a/admin_interface/static/admin_interface/css/widgets.css
+++ b/admin_interface/static/admin_interface/css/widgets.css
@@ -68,6 +68,16 @@
 }
 /* end-fix */
 
+/* Restore Django admin date/time popup widths overridden by module styles. */
+.admin-interface .calendarbox {
+    width: 19em;
+}
+
+.admin-interface .clockbox {
+    width: auto;
+}
+/* end-fix */
+
 /* fixed related widget and select2 */
 /* begin fix issue #10 - Related widget broken in long tabular inline */
 .admin-interface .related-widget-wrapper {


### PR DESCRIPTION
Fixes #469.

django-admin-interface applies width: 100% to .admin-interface .module. Django admin date/time picker popups are rendered as .calendarbox.module and .clockbox.module, so they inherit full module width and can expand across the page.

This adds widget-specific CSS rules to restore the default Django admin popup widths:
- .calendarbox -> 19em
- .clockbox -> auto

The generic module layout remains unchanged.